### PR TITLE
When saved/updated via admin panel, empty usernames get persisted

### DIFF
--- a/Block/SocialLinks.php
+++ b/Block/SocialLinks.php
@@ -115,6 +115,12 @@ class SocialLinks extends Template implements BlockInterface {
     public function getUsernames() {
         $parameters = $this->getWidgetParameters();
         unset($parameters['display_text']);
+        // ensure that only populated values are returned
+        foreach ($parameters as $network => $username) {
+            if (!$username) {
+                unset($parameters[$network]);
+            }
+        }
         return (!is_null($parameters)) ? $parameters :[] ;
     }
 


### PR DESCRIPTION
Fix removes empty usernames from array.